### PR TITLE
storage/memory: copy whole map instead of reference

### DIFF
--- a/storage/memory.go
+++ b/storage/memory.go
@@ -301,7 +301,10 @@ func (module *MemoryStorage) PartitionHighWaterMarks() map[string]PartitionWater
 
 	mapCopy := make(map[string]PartitionWaterMarks)
 	for key, value := range module.partitions.HighWaterMarks {
-		mapCopy[key] = value
+		mapCopy[key] = make(PartitionWaterMarks)
+		for partition, partitionData := range value {
+			mapCopy[key][partition] = partitionData
+		}
 	}
 
 	return mapCopy
@@ -315,7 +318,10 @@ func (module *MemoryStorage) PartitionLowWaterMarks() map[string]PartitionWaterM
 
 	mapCopy := make(map[string]PartitionWaterMarks)
 	for key, value := range module.partitions.LowWaterMarks {
-		mapCopy[key] = value
+		mapCopy[key] = make(PartitionWaterMarks)
+		for partition, partitionData := range value {
+			mapCopy[key][partition] = partitionData
+		}
 	}
 
 	return mapCopy


### PR DESCRIPTION
avoid concurrent map access in collector. i was not able to use kafka-minion without this fix, because it crashed after several minutes (or even earlier). the reason is most likely that we have a large number of partitions (1k); with a lower number the race didn't occur often.

the problem was that the map was not deep copied, but only the pointer to the map was copied (since it's a nested structure with a map in the map).