### PR TITLE
fix unit test timestamp

### DIFF
--- a/kafka/consumer_partition_offset_test.go
+++ b/kafka/consumer_partition_offset_test.go
@@ -21,7 +21,7 @@ func TestDecodeConsumerPartitionOffsetV3(t *testing.T) {
 		Topic:     "orders",
 		Partition: 0,
 		Offset:    16534,
-		Timestamp: time.Unix(0, 1558998332950),
+		Timestamp: time.Unix(1558998332, 0),
 	}
 
 	offset, err := newConsumerPartitionOffset(key, value, logger)


### PR DESCRIPTION
Corrected timestamp in unit test TestDecodeConsumerPartitionOffsetV3 after a recent change