### PR TITLE
Fix broker describe log dirs

### DIFF
--- a/kafka/cluster.go
+++ b/kafka/cluster.go
@@ -149,6 +149,25 @@ func (module *Cluster) describeLogDirs() {
 
 	for _, broker := range brokers {
 		go func(b *sarama.Broker) {
+			connected, err := b.Connected()
+			if err != nil {
+				resCh <- response{
+					BrokerID: b.ID(),
+					Res:      nil,
+					Err:      err,
+				}
+			}
+			if !connected {
+				err = b.Open(module.client.Config())
+				if err != nil {
+					resCh <- response{
+						BrokerID: b.ID(),
+						Res:      nil,
+						Err:      err,
+					}
+				}
+			}
+
 			res, err := b.DescribeLogDirs(req)
 			resCh <- response{
 				BrokerID: b.ID(),

--- a/kafka/cluster.go
+++ b/kafka/cluster.go
@@ -149,6 +149,8 @@ func (module *Cluster) describeLogDirs() {
 
 	for _, broker := range brokers {
 		go func(b *sarama.Broker) {
+			// try to open the connection with broker if not already established
+			// ignoring the error as the only possible one at this stage is AlreadyConnected
 			_ = b.Open(module.client.Config())
 			res, err := b.DescribeLogDirs(req)
 			resCh <- response{

--- a/kafka/cluster.go
+++ b/kafka/cluster.go
@@ -149,25 +149,7 @@ func (module *Cluster) describeLogDirs() {
 
 	for _, broker := range brokers {
 		go func(b *sarama.Broker) {
-			connected, err := b.Connected()
-			if err != nil {
-				resCh <- response{
-					BrokerID: b.ID(),
-					Res:      nil,
-					Err:      err,
-				}
-			}
-			if !connected {
-				err = b.Open(module.client.Config())
-				if err != nil {
-					resCh <- response{
-						BrokerID: b.ID(),
-						Res:      nil,
-						Err:      err,
-					}
-				}
-			}
-
+			_ = b.Open(module.client.Config())
 			res, err := b.DescribeLogDirs(req)
 			resCh <- response{
 				BrokerID: b.ID(),


### PR DESCRIPTION
On newer version of sarama lib a connection needs to be 
explicitly opened with broker in order to query it.