### PR TITLE
 IMPROVEMENT-upgrade-kafka-2.6

### DIFF
--- a/README.md
+++ b/README.md
@@ -15,7 +15,7 @@ Kafka minion is a prometheus exporter for Apache Kafka (v0.11.0.2+), created to 
 
 ## Features
 
-- [x] Supports Kafka 0.11.0.2 - 2.2.x (last updated 16th Jun 2019)
+- [x] Supports Kafka 0.11.0.2 - 2.6.x (last updated  6th Dec 2020)
 - [x] Fetches consumer group information directly from `__consumer_offsets` topic instead of querying single brokers for consumer group lags to ensure robustness in case of broker failures or leader elections
 - [x] Kafka SASL/SSL support
 - [x] Provides per consumergroup:topic lag metrics (removes a topic's metrics if a single partition metric in that topic couldn't be fetched)
@@ -72,8 +72,8 @@ Kubernetes users may want to use the Helm chart to deploy Kafka Minion: https://
 ### Grafana Dashboard
 
 You can import our suggested Grafana dashboards and modify them as you wish:
- - https://grafana.com/dashboards/10083 (Kafka Minion Dashboard ID 10083)
- - https://grafana.com/dashboards/10466 (Kafka Minion OPS Dashbaord ID 10466)
+- https://grafana.com/dashboards/10083 (Kafka Minion Dashboard ID 10083)
+- https://grafana.com/dashboards/10466 (Kafka Minion OPS Dashbaord ID 10466)
 
 ## Exposed metrics
 
@@ -154,7 +154,7 @@ At a high level Kafka Minion fetches data from two different sources (see below)
 
 ### Why did you create yet another kafka lag exporter?
 
-1. As of writing the exporter there is no publicly available prometheus exporter (to my knowledge) which is lightweight, robust and supports Kafka v0.11 - v2.1+
+1. As of writing the exporter there is no publicly available prometheus exporter (to my knowledge) which is lightweight, robust and supports Kafka v0.11 - v2.6+
 
 2. We are primarily interested in per consumergroup:topic lags. Some exporters export either only group lags of all topics altogether or they export only per partition metrics. While you can obviously aggregate those partition metrics in Grafana as well, this adds unnecessary complexity in Grafana dashboards. This exporter offers metrics on partition and topic granularity.
 

--- a/docker-compose-kafka-2.6.yml
+++ b/docker-compose-kafka-2.6.yml
@@ -1,0 +1,45 @@
+---
+version: '2.1'
+
+services:
+
+  zookeeper:
+    image: confluentinc/cp-zookeeper:6.0.0
+    ports:
+      - 2181:2181
+    environment:
+      ZOOKEEPER_CLIENT_PORT: 2181
+      ZOOKEEPER_TICK_TIME: 2000
+    container_name: zookeeper
+    hostname: zookeeper
+
+  kafka:
+    image: confluentinc/cp-kafka:6.0.0
+    hostname: kafka
+    container_name: kafka
+    depends_on:
+      - zookeeper
+    ports:
+      - 9092:9092
+    environment:
+      KAFKA_BROKER_ID: 1
+      KAFKA_ZOOKEEPER_CONNECT: zookeeper:2181
+      KAFKA_ADVERTISED_LISTENERS: PLAINTEXT://kafka:29092,PLAINTEXT_HOST://localhost:9092
+      KAFKA_LISTENER_SECURITY_PROTOCOL_MAP: PLAINTEXT:PLAINTEXT,PLAINTEXT_HOST:PLAINTEXT
+      KAFKA_INTER_BROKER_LISTENER_NAME: PLAINTEXT
+      KAFKA_OFFSETS_TOPIC_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_REPLICATION_FACTOR: 1
+      KAFKA_TRANSACTION_STATE_LOG_MIN_ISR: 1
+
+  kafka-minion:
+    image: local-kafka-minion # it's my local build image, don't forget to update this to use the official kafka-minion image :)
+    hostname: kafka-minion
+    container_name: kafka-minion
+    depends_on:
+      - zookeeper
+      - kafka
+    ports:
+      - 8080:8080
+    environment:
+      KAFKA_BROKERS: kafka:29092
+    restart: unless-stopped


### PR DESCRIPTION
Hello, 

I just had a new docker-compose file to check the compatibility of the lib with kafka 2.6+. 

I push data with ksql-datagen, launch consumer with console-consumer; everything seems good (it's not a surprise). 

I update the Readme to fix the lines which indicates supported version. 

(I will remove the docker-compose file, it's just to see you what I've made) 

Don't hesitate to ping me if you have any questions ! 

have a nice day 